### PR TITLE
docs: prepare v0.1.0 baseline release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.1.0] - 2026-02-11
+
+Initial public baseline release for `my-opencode-codex-setup`.
+
+### Added
+
+- Phase 1 bootstrap repository structure with installer and core docs.
+- Phase 2 practical skill pack for git/github, security, CI/CD, Docker, Helm, language conventions, and Terraform.
+- Phase 3 hardened core agent pack (`architect`, `skeptic`, `craftsman`, `operator`, `chronicler`, `scout`) with role boundaries and playbook.
+- Phase 4 executable workflow scripts:
+  - `scripts/handover.sh`
+  - `scripts/git-porcelain.sh`
+  - `scripts/ops-check.sh`
+  - `scripts/issue-pr-loop.sh`
+- Phase 5 open-source readiness kit:
+  - GitHub issue and PR templates
+  - `CODE_OF_CONDUCT.md`
+  - `SECURITY.md`
+  - examples and release checklist docs
+
+### Notes
+
+- This release establishes the baseline for future semantic versioning.
+- OpenCode/Codex command and agent mappings will continue to evolve in subsequent minor releases.


### PR DESCRIPTION
## Summary
- add `CHANGELOG.md` with the v0.1.0 baseline release notes
- document the five completed phases as the initial public baseline
- establish semantic versioning release starting point

## Testing
- not applicable (documentation-only release prep)